### PR TITLE
Update for Elixir 1.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LoggerFileBackend.Mixfile do
   def project do
     [app: :logger_file_backend,
      version: "0.0.6",
-     elixir: ">= 1.0.0 and <= 1.2.0",
+     elixir: "~> 1.0",
      description: description,
      package: package,
      deps: deps]


### PR DESCRIPTION
Prior to this commit, LoggerFileBackend accepted any Elixir version between 1.0.0 and 1.2.0; however, 1.2.1 was just released and fails this check, as would any further future release. This commit changes the acceptable version to `~> 1.0`, which will expands to `>= 1.0 and < 2.0`. Since Elixir follows SemVer, we should should work with any future release up to a potentially backwards incompatible 2.0.