### PR TITLE
Handle the :flush event introduced in Elixir v1.3.0

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -37,6 +37,11 @@ defmodule LoggerFileBackend do
     end
   end
 
+  def handle_event(:flush, state) do
+    # We're not buffering anything so this is a no-op
+    {:ok, state}
+  end
+
 
   # helpers
 


### PR DESCRIPTION
This change prevents `LoggerFileBackend` from crashing when using Elixir v1.3.0.