### PR TITLE
Fix warnings by elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule LoggerFileBackend.Mixfile do
     [app: :logger_file_backend,
      version: "0.0.10",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
ex) warning: variable "description" does not exist and is being expanded
to "description()", please use parentheses to remove the ambiguity or
change the variable name