### PR TITLE
Silencing compile warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule LoggerFileBackend.Mixfile do
     [app: :logger_file_backend,
      version: "0.0.10",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Silencing the warnings that happen every time a dependent project runs `mix compile`.  ^.^

```sh
$ mix compile
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  c:/Users/<user>/Projects/my_server/deps/logger_file_backend/mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  c:/Users/<user>/Projects/my_server/deps/logger_file_backend/mix.exs:9

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  c:/Users/<user>/Projects/my_server/deps/logger_file_backend/mix.exs:10

Compiling 1 file (.ex)
```