### PR TITLE
add date rotate option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule LoggerFileBackend.Mixfile do
     [app: :logger_file_backend,
      version: "0.0.10",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Usage example: 

```
config :logger, :ecto,
  path: Path.expand("./logs/ecto.log"),
  metadata_filter: [application: :ecto],
  rotate: %{period: :date, keep: 10}
```

Will keep logs for the last 10 days

The PR inspired by this PR #33 plus fixes for Elixir 1.4 and some coding style improvements.