### PR TITLE
Update runtime example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ multiple log files.
 
 ```elixir
 Logger.add_backend {LoggerFileBackend, :debug}
-Logger.configure {LoggerFileBackend, :debug},
+Logger.configure_backend {LoggerFileBackend, :debug},
   path: "/path/to/debug.log",
   format: ...,
   metadata: ...,


### PR DESCRIPTION
Hi @onkel-dirtus,

I was following the [example](https://github.com/onkel-dirtus/logger_file_backend#runtime-configuration) in the readme for configuring a backend at runtime and encountered a compilation warning:
```
warning: function Logger.configure/2 is undefined or private. Did you mean one of:
      * configure/1
```

I believe `configure_backend` is the method that should be used for for configuring a backend, see https://hexdocs.pm/logger/Logger.html#configure_backend/2