### PR TITLE
Fix Elixir v1.5 GenEvent deprecation warnings

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -2,7 +2,8 @@ defmodule LoggerFileBackend do
   @moduledoc"""
   """
 
-  use GenEvent
+  @behaviour :gen_event
+
 
   @type path      :: String.t
   @type file      :: :file.io_device

--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -194,7 +194,7 @@ defmodule LoggerFileBackendTest do
   end
 
   defp path do
-    {:ok, path} = GenEvent.call(Logger, @backend, :path)
+    {:ok, path} = :gen_event.call(Logger, @backend, :path)
     path
   end
 


### PR DESCRIPTION
Elixir v1.5 has officially deprecated GenEvent slating it for
removal by v2.0. For the time being Logger continues to be based
on Erlang's :gen_event behavior. This update silences the GenEvent
deprecation warnings by replacing GenEvent with :gen_event.