### PR TITLE
Implement default handle_info callback

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -44,6 +44,10 @@ defmodule LoggerFileBackend do
   end
 
 
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
   # helpers
 
   defp log_event(_level, _msg, _ts, _md, %{path: nil} = state) do


### PR DESCRIPTION

Aims to fix behaviour described in issue #42 
>I get tons of warnings like
>12:57:34.611 [warn]  ** Undefined handle_info in LoggerFileBackend
>** Unhandled message: {:io_reply, #Reference<0.1509840159.3980918785.102111>, :ok}
>Please check what callback functions erlang's gen_event requires to be defined explicitly.

Here is a screenshot of the undesired behavior I encountered when dynamically adding this backend:
![screen shot 2017-10-10 at 9 27 18 pm](https://user-images.githubusercontent.com/10237004/31419545-73ee4890-ae0a-11e7-8149-1b3db21d89de.png)

Looking at the Erlang [docs for `gen_event`'s `handle_info`](http://erlang.org/doc/man/gen_event.html#Module:handle_info-2):
>This callback is optional, so callback modules need not export it. The gen_event module provides a default implementation of this function that logs about the unexpected Info message, drops it and returns {noreply, State}.

## Proposed solution
Implement the `handle_info` callback with the (deprecated) `GenEvent` [default](https://github.com/elixir-lang/elixir/blob/7b8d5ec289293d13eb0a48186e3f899786a7cd33/lib/elixir/lib/gen_event.ex#L127)

With a test implementation like the following and a program that runs `Logger.info msg` every ~5 seconds:
```
  def handle_info(msg, state) do
    IO.puts(inspect msg)
    {:ok, state}
  end
```
I got the following behavior:
![screen shot 2017-10-10 at 10 43 24 pm](https://user-images.githubusercontent.com/10237004/31419915-76d12422-ae0c-11e7-9424-1b6f25431dd8.png)

We see we no longer get constant warnings and `handle_info` is called every time we log something.
