### PR TITLE
Minor README fix for metadata example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This example only writes log statements with a custom metadata key to the file.
 config :logger,
   backends: [{LoggerFileBackend, :device_1}]
 
-config :logger, :device_1
+config :logger, :device_1,
   path: "/path/to/device_1.log",
   level: :debug,
   metadata_filter: [device: 1]


### PR DESCRIPTION
The metadata example config.exs block was missing a comma. Using it verbatim will generate the following error during compilation:

```
** (Mix.Config.LoadError) could not load config config/config.exs
    ** (SyntaxError) config/config.exs:35: syntax error before: path
```