### PR TITLE
Allow :all in :metadata option

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -43,6 +43,9 @@ defmodule LoggerFileBackend do
     {:ok, state}
   end
 
+  def handle_info(_, state) do
+    {:ok, state}
+  end
 
   # helpers
 

--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -137,6 +137,8 @@ defmodule LoggerFileBackend do
 
 
 
+  defp take_metadata(metadata, :all), do: metadata
+
   defp take_metadata(metadata, keys) do
     metadatas = Enum.reduce(keys, [], fn key, acc ->
       case Keyword.fetch(metadata, key) do

--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -177,6 +177,22 @@ defmodule LoggerFileBackendTest do
 
   end
 
+  test "Allow :all to metadata" do
+    config format: "$metadata"
+
+    config metadata: []
+    Logger.debug "metadata", metadata1: "foo", metadata2: "bar"
+    assert log() == ""
+
+    config metadata: [:metadata3]
+    Logger.debug "metadata", metadata3: "foo", metadata4: "bar"
+    assert log() == "metadata3=foo "
+
+    config metadata: :all
+    Logger.debug "metadata", metadata5: "foo", metadata6: "bar"
+    assert Regex.match?(~r/ ?metadata5\=foo metadata6\=bar ?/, log())
+  end
+
   defp has_open(path) do
     has_open(:os.type, path)
   end


### PR DESCRIPTION
Hi @onkel-dirtus 

I have allowed `:all` to `:metadata` option because it is supported by `Elixir.Logger.Backends.Console`.
I need this option to edit metadata with my custom formatter.
https://hexdocs.pm/logger/Logger.html#module-console-backend
