### PR TITLE
Make test suite more robust

### DIFF
--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -190,7 +190,11 @@ defmodule LoggerFileBackendTest do
 
     config metadata: :all
     Logger.debug "metadata", metadata5: "foo", metadata6: "bar"
-    assert Regex.match?(~r/ ?metadata5\=foo metadata6\=bar ?/, log())
+
+    # Match separately for metadata5/metadata6 to avoid depending on order
+    contents = log()
+    assert contents =~ "metadata5=foo"
+    assert contents =~ "metadata6=bar"
   end
 
   defp has_open(path) do

--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -7,9 +7,6 @@ defmodule LoggerFileBackendTest do
 
   import LoggerFileBackend, only: [prune: 1, metadata_matches?: 2]
 
-  # add the backend here instead of `config/test.exs` due to issue 2649
-  Logger.add_backend @backend
-
   setup_all do
     on_exit fn ->
       File.rm_rf!(@basedir)
@@ -17,12 +14,13 @@ defmodule LoggerFileBackendTest do
   end
 
   setup context do
+    # We add and remove the backend here to avoid cross-test effects
+    Logger.add_backend(@backend, flush: true)
+
     config [path: logfile(context, @basedir), level: :debug]
 
     on_exit fn ->
-      # Synchronize with logger to ensure that we are finished before trying to run
-      # the next test
-      {:ok, _path} = :gen_event.call(Logger, @backend, :path)
+      :ok = Logger.remove_backend(@backend)
     end
   end
 
@@ -161,7 +159,6 @@ defmodule LoggerFileBackendTest do
     Logger.debug "rotate4"
     Logger.debug "rotate5"
     Logger.debug "rotate6"
-
 
     p = path()
 

--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -3,16 +3,26 @@ defmodule LoggerFileBackendTest do
   require Logger
 
   @backend {LoggerFileBackend, :test}
+  @basedir "test/logs"
 
   import LoggerFileBackend, only: [prune: 1, metadata_matches?: 2]
 
   # add the backend here instead of `config/test.exs` due to issue 2649
   Logger.add_backend @backend
 
-  setup do
-    config [path: "test/logs/test.log", level: :debug]
+  setup_all do
     on_exit fn ->
-      path() && File.rm_rf!(Path.dirname(path()))
+      File.rm_rf!(@basedir)
+    end
+  end
+
+  setup context do
+    config [path: logfile(context, @basedir), level: :debug]
+
+    on_exit fn ->
+      # Synchronize with logger to ensure that we are finished before trying to run
+      # the next test
+      {:ok, _path} = :gen_event.call(Logger, @backend, :path)
     end
   end
 
@@ -223,6 +233,14 @@ defmodule LoggerFileBackendTest do
   end
 
   defp config(opts) do
-    Logger.configure_backend(@backend, opts)
+    :ok = Logger.configure_backend(@backend, opts)
+  end
+
+  defp logfile(context, basedir) do
+    logfile =
+      context.test
+      |> Atom.to_string()
+      |> String.replace(" ", "_")
+    Path.join(basedir, logfile)
   end
 end


### PR DESCRIPTION
The commits here make the tests more robust by using a single log file for each test, synchronizing with the Logger and by making the test for metadata not depend on metadata output ordering.