### PR TITLE
Eliminate warning raised by Elixir v1.11 compiler

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule LoggerFileBackend.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [extra_applications: [:logger]]
   end
 
   defp description do


### PR DESCRIPTION
When the app is a dependency the following warning pops up using v1.11-dev Elixir.

```
warning: Logger.compare_levels/2 defined in application :logger is used by the current application but the current application does not directly depend on :logger. To fix this, you must do one of:

  1. If :logger is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :logger is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :logger, you may optionally skip this warning by adding [xref: [exclude: Logger] to your "def project" in mix.exs

  lib/logger_file_backend.ex:36: LoggerFileBackend.handle_event/2
```