### PR TITLE
Add :logger to extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule LoggerFileBackend.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [], extra_applications: [:logger]]
   end
 
   defp description do


### PR DESCRIPTION
The `:extra_applications` key is required when depending on built-in OTP applications: https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html

This update fixes warnings showing up in Elixir 1.11 related to this.