### PR TITLE
list logger in extra applications for Elixir 1.11 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,10 @@ defmodule LoggerFileBackend.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [
+      applications: [],
+      extra_applications: [:logger]
+    ]
   end
 
   defp description do


### PR DESCRIPTION
Elixir 1.11 includes [application boundary checks at compile-time](https://elixir-lang.org/blog/2020/10/06/elixir-v1-11-0-released/#compiler-checks-application-boundaries). Logger now should be listed as an extra application in mix.exs to avoid warnings during compilation.
