### PR TITLE
Releasing file descriptor when backend is removed

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -46,6 +46,14 @@ defmodule LoggerFileBackend do
     {:ok, state}
   end
 
+  def handle_info({:EXIT, _pid, _reason}, %{io_device: io_device} = state)
+      when not is_nil(io_device) do
+    case File.close(io_device) do
+      :ok -> {:ok, state}
+      {:error, reason} -> raise "failure while closing file for reason: #{reason}"
+    end
+  end
+
   def handle_info(_, state) do
     {:ok, state}
   end


### PR DESCRIPTION
This PR deals with releasing the file descriptor in case the backend has removed. 

### Linked issue 
This PR has linked to this issue [#68](https://github.com/onkel-dirtus/logger_file_backend/issues/68)

### Proposed solution
I replicate the problem with the example described in issue  [#68](https://github.com/onkel-dirtus/logger_file_backend/issues/68).
The file, in this case, is not released because when the `Logger.remove_backend(...)` method is invoked the `:gen_event` behavior does not catch the exit signal in the `handle_info` callback.
The solution I propose is to make a pattern match on the exit signal and in this callback close the file.

Let me know what think about it, I'm happy to help with this project that I find very useful. :D