### PR TITLE
metadata_filter able to group multiple application logs

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -145,6 +145,17 @@ defmodule LoggerFileBackend do
   # all of the filter keys are present
   def metadata_matches?(_md, []), do: true
 
+  def metadata_matches?(md, [{key, [_ | _] = val} | rest]) do
+    case Keyword.fetch(md, key) do
+      {:ok, md_val} ->
+        (md_val in val) && metadata_matches?(md, rest)
+
+      # fail on first mismatch
+      _ ->
+        false
+    end
+  end
+
   def metadata_matches?(md, [{key, val} | rest]) do
     case Keyword.fetch(md, key) do
       {:ok, ^val} ->

--- a/test/logger_file_backend_test.exs
+++ b/test/logger_file_backend_test.exs
@@ -43,6 +43,8 @@ defmodule LoggerFileBackendTest do
   test "metadata_matches?" do
     # exact match
     assert metadata_matches?([a: 1], a: 1) == true
+    # included in array match
+    assert metadata_matches?([a: 1], a: [1, 2]) == true
     # total mismatch
     assert metadata_matches?([b: 1], a: 1) == false
     # default to allow


### PR DESCRIPTION
Scenario:
there are several applications in an umbrella project. eg
```
finance_umbrella/
   apps/
       client_portal/
       client_portal_web/
       crm/
       crm_web/
       ...
```

in such case. we prefer to log both client_portal and client_portal_web into a single log file **client_portal.log**, instead of two isolated files **client_portal.log** **client_portal_web.logs**.

So we enhance metadata_filter supports array.

```elixir
config :logger,
  backends: [
    {LoggerFileBackend, :client_portal},
    {LoggerFileBackend, :crm}
  ]

config :logger, :client_portal,
  path: "/path/to/client_portal.log",
  level: :info,
  metadata_filter: [application: [:client_portal, :client_portal_web]]

config :logger, :client_portal,
  path: "/path/to/crm.log",
  level: :info,
  metadata_filter: [application: [:crm, :crm_web]]

```



       