### PR TITLE
fix: warnings about the use of deprecated :warn

### DIFF
--- a/lib/logger_file_backend.ex
+++ b/lib/logger_file_backend.ex
@@ -34,6 +34,9 @@ defmodule LoggerFileBackend do
         %{level: min_level, metadata_filter: metadata_filter, metadata_reject: metadata_reject} =
           state
       ) do
+    level = to_logger_level(level)
+    min_level = to_logger_level(min_level)
+
     if (is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt) and
          metadata_matches?(md, metadata_filter) and
          (is_nil(metadata_reject) or !metadata_matches?(md, metadata_reject)) do
@@ -259,4 +262,12 @@ defmodule LoggerFileBackend do
 
   defp prune_binary(<<>>, acc),
     do: acc
+
+  defp to_logger_level(:warn) do
+    if Version.compare(System.version(), "1.11.0") != :lt,
+      do: :warning,
+      else: :warn
+  end
+
+  defp to_logger_level(level), do: level
 end


### PR DESCRIPTION
In Elixir 1.11 `Logger.warn` was deprecated in favor of `Logger.warning` and logs a warning when `warn` is used. To stay backward compatible Logger itself reports level `warning` as `warn` to backends [^1].

When a backend passes `warn` to `Logger`, essentially feeding the module it' own food, Logger will issue a warning about the use of `warn` [^2].

The proposed solution is to convert `warn` to `warning` when a system runs Elixir >= 1.11.

[^1]: https://hexdocs.pm/logger/1.11.3/Logger.html#warning/2
[^2]: https://github.com/elixir-lang/elixir/blob/ad4c31eef1af836c3c9972f67b5deb6b0a541c53/lib/logger/lib/logger.ex#L1171